### PR TITLE
Adds ._.* files to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target
 .settings
 *.iml
 .DS_STORE
+
+# Ignore temp files from Sublime.
+._.*


### PR DESCRIPTION
Sublime creates these annoying ._. files for SSHFS. This ignores them in
the git repository, so I don't accidentally commit them.