### PR TITLE
Changes dependencies to use npm repository.

### DIFF
--- a/src/main/webapp/package-lock.json
+++ b/src/main/webapp/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "codeu_project_2018",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "emoji-datasource": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-datasource/-/emoji-datasource-4.0.0.tgz",
+      "integrity": "sha1-P8nAwvT7Mh2SkROIGfbRAGA9Pi8="
+    },
+    "emoji-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-js/-/emoji-js-3.4.0.tgz",
+      "integrity": "sha1-2r3tpgyS0ZSKUXflG6lCHSApsFI=",
+      "requires": {
+        "emoji-datasource": "4.0.0"
+      }
+    },
+    "eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
+    "textarea-caret": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.1.0.tgz",
+      "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
+    },
+    "textcomplete": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/textcomplete/-/textcomplete-0.17.1.tgz",
+      "integrity": "sha512-vxHXk8h/pPh5GW5L872H7Ui/uxhoLn5fh9FNYrOW9sNpRVuLs53QiTTLDwfEjK6lOuUb7AA26DsRPhwBl1QFiA==",
+      "requires": {
+        "eventemitter3": "2.0.3",
+        "textarea-caret": "3.1.0",
+        "undate": "0.2.4"
+      }
+    },
+    "undate": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/undate/-/undate-0.2.4.tgz",
+      "integrity": "sha512-k1WTRVhI076HYqP6e3pZPzS7K2xNAcuhCcWOPjHmR8SwU3byyKYvyNZ4XTEAd7Ofe40+wrEjNq6WmmO8WoUVNg=="
+    }
+  }
+}

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -4,8 +4,8 @@
   "description": "Google CodeU project Team 31, 2018",
   "main": "index.js",
   "dependencies": {
-    "emoji-js": "iamcal/js-emoji.git#9f5cfd92111088c54e48a60d424dc3d69473306d",
-    "textcomplete": "yuku-t/textcomplete.git#6f07195c47ace5e787cf7b46604b37a8bd5c6d30"
+    "emoji-js": "^3.4.0",
+    "textcomplete": "^0.17.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The git repo+hash dependencies were broken, and this allows us to use a
locked package definition using release version numbers.