### PR TITLE
Fixes bugs in Datastore

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -21,6 +21,7 @@ import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.TagStore;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -49,6 +50,9 @@ public class ChatServlet extends HttpServlet {
   /** Store class that gives access to Users. */
   private UserStore userStore;
 
+  /** Store class that gives access to Tags. */
+  private TagStore tagStore;
+
   /** Set up state for handling chat requests. */
   @Override
   public void init() throws ServletException {
@@ -56,6 +60,7 @@ public class ChatServlet extends HttpServlet {
     setConversationStore(ConversationStore.getInstance());
     setMessageStore(MessageStore.getInstance());
     setUserStore(UserStore.getInstance());
+    setTagStore(TagStore.getInstance());
   }
 
   /**
@@ -83,6 +88,14 @@ public class ChatServlet extends HttpServlet {
   }
 
   /**
+   * Sets the TagStore used by this servlet. This function provides a common setup method for use
+   * by the test framework or the servlet's init() function.
+   */
+  void setTagStore(TagStore tagStore) {
+    this.tagStore = tagStore;
+  }
+
+  /**
    * This function fires when a user navigates to the chat page. It gets the conversation title from
    * the URL, finds the corresponding Conversation, and fetches the messages in that Conversation.
    * It then forwards to chat.jsp for rendering.
@@ -106,13 +119,16 @@ public class ChatServlet extends HttpServlet {
     List<Message> messages = messageStore.getMessagesInConversation(conversationId);
     
     // Get all of this conversation's tags
-    List<Tag> tags = conversation.getTags();
+    List<Tag> tags = tagStore.getAllTags();
+    List<Tag> convoTags = new ArrayList<>();
     for (Tag tag : tags) {
-      System.out.print(tag.getTag());
+      if (tag.getConversation().equals(conversationId)) {
+        convoTags.add(tag);
+      }
     }
 
     // Pass the List of Tags to chat.jsp
-    request.setAttribute("tags", tags);
+    request.setAttribute("tags", convoTags);
     request.setAttribute("conversation", conversation);
     request.setAttribute("messages", messages);
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -19,6 +19,7 @@ import codeu.model.data.Tag;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.TagStore;
 import com.google.appengine.repackaged.com.google.api.client.util.Lists;
 import java.io.IOException;
 import java.time.Instant;
@@ -39,6 +40,9 @@ public class ConversationServlet extends HttpServlet {
   /** Store class that gives access to Conversations. */
   private ConversationStore conversationStore;
 
+  /** Store class that gives access to Tags. */
+  private TagStore tagStore;
+
   /**
    * Set up state for handling conversation-related requests. This method is only called when
    * running in a server, not when running in a test.
@@ -48,6 +52,7 @@ public class ConversationServlet extends HttpServlet {
     super.init();
     setUserStore(UserStore.getInstance());
     setConversationStore(ConversationStore.getInstance());
+    setTagStore(TagStore.getInstance());
   }
 
   /**
@@ -64,6 +69,14 @@ public class ConversationServlet extends HttpServlet {
    */
   void setConversationStore(ConversationStore conversationStore) {
     this.conversationStore = conversationStore;
+  }
+
+  /**
+   * Sets the TagStore used by this servlet. This function provides a common setup method
+   * for use by the test framework or the servlet's init() function.
+   */
+  void setTagStore(TagStore tagStore) {
+    this.tagStore = tagStore;
   }
 
   /**
@@ -130,17 +143,12 @@ public class ConversationServlet extends HttpServlet {
 
       List<String> splitTags = Arrays.asList(tags.split(", "));
       for (String tag : splitTags) {
-        // TODO: Check if Tag already exists in TagStore
-
-        // Create new Tag object. Use the lowercase version of the tag string to
-        // ensure case insensitivity
         Tag newTag = new Tag(UUID.randomUUID(), conversation.getId(), tag.toLowerCase(), Instant.now());
-        conversation.addTag(newTag);
+        tagStore.addTag(newTag);
       }
-      conversationStore.putConversation(conversation);
-    }
 
     conversationStore.addConversation(conversation);
     response.sendRedirect("/chat/" + conversationTitle);
+    }
   }
 }

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -3,9 +3,11 @@ package codeu.controller;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.Tag;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.TagStore;
 import codeu.model.store.persistence.PersistentDataStoreException;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.List;
@@ -30,6 +32,9 @@ public class ServerStartupListener implements ServletContextListener {
 
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);
+
+      List<Tag> tags = PersistentStorageAgent.getInstance().loadTags();
+      TagStore.getInstance().setTags(tags);
 
     } catch (PersistentDataStoreException e) {
       System.err.println("Server didn't start correctly. An error occurred during Datastore load!");

--- a/src/main/java/codeu/controller/TagServlet.java
+++ b/src/main/java/codeu/controller/TagServlet.java
@@ -90,15 +90,22 @@ public class TagServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
       throws IOException, ServletException {
+
+    String username = (String) request.getSession().getAttribute("user");
+    if (username == null) {
+      // User is not logged in, don't let them see a profile
+      System.out.println("Please login before viewing tagged conversations");
+      response.sendRedirect("/login");
+      return;
+    }
+
     String requestUrl = request.getRequestURI();
     Matcher m = Pattern.compile("^/tag/(.+)").matcher(requestUrl);
     if (!m.find()) {
       System.out.println("wrong URL pattern: " + requestUrl);
       return; // return error 
     }
-
     String extractedTag = m.group(1);
-
     List<String> conversationTitles = new ArrayList<>();
 
     // Sets request attribute to a list of Conversation titles that are associated with the Tag

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -28,7 +28,6 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
-  private List<Tag> tags;
 
   /**
    * Constructs a new Conversation.
@@ -43,18 +42,6 @@ public class Conversation {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-    tags = new ArrayList<>();
-  }
-
-  /** Adds a tag to this Conversation. */
-  public void addTag(Tag tag) {
-    tags.add(tag);
-  }
-
-  /** Returns an alphabetically sorted list of Tags */
-  public List<Tag> getTags() {
-    tags.sort(new TagComparator());
-    return tags;
   }
 
   /** Returns the ID of this Conversation. */

--- a/src/main/java/codeu/model/data/Tag.java
+++ b/src/main/java/codeu/model/data/Tag.java
@@ -17,8 +17,7 @@ public class Tag {
    * Constructs a new Tag.
    *
    * @param id the ID of this Tag
-   * @param conversationId the Id of the first Conversation this Tag is associated with.
-   * @param conversations the Ids of the Conversations this Tag belongs to
+   * @param conversationId the Id of the Conversation this Tag is associated with.
    * @param tag the content of this Tag
    * @param creation the creation time of this Tag
    */
@@ -28,18 +27,6 @@ public class Tag {
     this.conversationId = conversationId;
     this.tag = tag;
     this.creation = creation;
-    this.conversations = new ArrayList<>();
-    this.conversations.add(conversationId);
-  }
-
-  /** Adds a Conversation that has this Tag */
-  public void addConversation(UUID conversationId) {
-    conversations.add(conversationId);
-  }
-
-  /** Gets all Conversations that have this Tag */
-  public List<UUID> getConversations() {
-    return conversations;
   }
 
   /** Gets the Conversation that this Tag was created with*/

--- a/src/main/java/codeu/model/store/basic/TagStore.java
+++ b/src/main/java/codeu/model/store/basic/TagStore.java
@@ -84,21 +84,6 @@ public class TagStore {
     return loaded;
   }
 
-  /**
-   * Access the Tag object with the given name.
-   *
-   * @return null if Tag name does not match any existing Tag.
-   */
-  public Tag getTag(String tag_contents) {
-    // This approach will be pretty slow if we have many tags.
-    for (Tag t : tags) {
-      if (tag_contents.equals(t.getTag())) {
-        return t;
-      }
-    }
-    return null;
-  }
-
   /** Access the current set of tags known to the application. */
   public List<Tag> getAllTags() {
     return tags;
@@ -124,12 +109,7 @@ public class TagStore {
     return tagsInConversation;
   }
 
-  /** Access the current set of Conversations within the given Tag. */
-  public List<UUID> getConversationsInTag(Tag tag) {
-    return tag.getConversations();
-  }
-
-   /** Check whether a Conversation title is already known to the application. */
+   /** Check whether a Tag title is already known to the application. */
   public boolean isTagTaken(String tag) {
     // This approach will be pretty slow if we have many Conversations.
     for (Tag t : tags) {

--- a/src/main/java/codeu/model/store/basic/TagStore.java
+++ b/src/main/java/codeu/model/store/basic/TagStore.java
@@ -109,7 +109,7 @@ public class TagStore {
     return tagsInConversation;
   }
 
-   /** Check whether a Tag title is already known to the application. */
+  /** Check whether a Tag title is already known to the application. */
   public boolean isTagTaken(String tag) {
     // This approach will be pretty slow if we have many Conversations.
     for (Tag t : tags) {

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -68,7 +68,7 @@ User loggedInUser = UserStore.getInstance().getUser(user);
     <% if (loggedInUser != null) { %>
         <label class="form-control-label">Current tags:</label>
         <p>
-        <% List<Tag> tags = (List<Tag>)request.getAttribute("tags");
+        <% List<Tag> tags = (List<Tag>) request.getAttribute("tags");
            for (Tag tag : tags) {
              String tagName = tag.getTag();
         %>

--- a/src/main/webapp/WEB-INF/view/tag.jsp
+++ b/src/main/webapp/WEB-INF/view/tag.jsp
@@ -24,7 +24,8 @@
 
 <%
 String user = (String) request.getSession().getAttribute("user");
-Tag tag = (Tag) request.getAttribute("extracted_tag");
+String tag = (String) request.getAttribute("extracted_tag");
+List<String> conversationTitles = (List<String>) request.getAttribute("conversations");
 User loggedInUser = UserStore.getInstance().getUser(user);
 ConversationStore conversationStore = ConversationStore.getInstance();
 %>
@@ -59,16 +60,15 @@ ConversationStore conversationStore = ConversationStore.getInstance();
 
   <div id="container">
 
-    <h1> <%= tag.getTag() %></h1>
-    <h2> Check out other conversations with tagged with <%= tag.getTag() %>! </h2>
-    <% for (UUID convo : (List<UUID>) tag.getConversations()) { 
-        String conversationTitle = conversationStore.getConversationWithID(convo).getTitle();
+    <h1> <%= tag %></h1>
+    <h2> Check out other conversations with tagged with <%= tag %>! </h2>
+    <ul class="mdl-list"> 
+    <% for (String convo : conversationTitles) { 
     %>
-        <ul class="mdl-list"> 
-          <li><a href="/chat/<%= conversationTitle %>">
-          <%= conversationTitle %></a></li>
-        </ul>
+          <li><a href="/chat/<%= convo %>">
+          <%= convo %></a></li>
     <% } %> 
+    </ul>
   </div>
 
 </body>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -17,9 +17,11 @@ package codeu.controller;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.Tag;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.TagStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -46,6 +48,7 @@ public class ChatServletTest {
   private ConversationStore mockConversationStore;
   private MessageStore mockMessageStore;
   private UserStore mockUserStore;
+  private TagStore mockTagStore;
 
   static final String TEST_USERNAME = "test username";
   static final String TEST_PASSWORD = "test password";
@@ -72,6 +75,9 @@ public class ChatServletTest {
 
     mockUserStore = Mockito.mock(UserStore.class);
     chatServlet.setUserStore(mockUserStore);
+
+    mockTagStore = Mockito.mock(TagStore.class);
+    chatServlet.setTagStore(mockTagStore);
   }
 
   @Test
@@ -94,6 +100,15 @@ public class ChatServletTest {
             Instant.now()));
     Mockito.when(mockMessageStore.getMessagesInConversation(fakeConversationId))
         .thenReturn(fakeMessageList);
+
+    List<Tag> fakeTagList = new ArrayList<>();
+    fakeTagList.add(
+        new Tag(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "test tag",
+            Instant.now()));
+    Mockito.when(mockTagStore.getAllTags()).thenReturn(fakeTagList);  
 
     chatServlet.doGet(mockRequest, mockResponse);
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -16,8 +16,10 @@ package codeu.controller;
 
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
+import codeu.model.data.Tag;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.TagStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -43,11 +45,13 @@ public class ConversationServletTest {
   private RequestDispatcher mockRequestDispatcher;
   private ConversationStore mockConversationStore;
   private UserStore mockUserStore;
+  private TagStore mockTagStore;
 
   static final String TEST_USERNAME = "test_username";
   static final String TEST_PASSWORD = "test_password";
   static final String TEST_ABOUT = "test_about";
   static final String TEST_CONVERSATION = "test_conversation";
+  static final String TEST_TAG = "test_tag";
 
   @Before
   public void setup() {
@@ -67,6 +71,9 @@ public class ConversationServletTest {
 
     mockUserStore = Mockito.mock(UserStore.class);
     conversationServlet.setUserStore(mockUserStore);
+
+    mockTagStore = Mockito.mock(TagStore.class);
+    conversationServlet.setTagStore(mockTagStore);
   }
 
   @Test
@@ -147,6 +154,7 @@ public class ConversationServletTest {
     Mockito.when(mockSession.getAttribute("user")).thenReturn(TEST_USERNAME);
     Mockito.when(mockSession.getAttribute("password")).thenReturn(TEST_PASSWORD);
     Mockito.when(mockSession.getAttribute("about")).thenReturn(TEST_ABOUT);
+    Mockito.when(mockRequest.getParameter("tags")).thenReturn(TEST_TAG);
 
     User fakeUser = new User(UUID.randomUUID(), TEST_USERNAME, Instant.now(), TEST_PASSWORD, TEST_ABOUT);
     Mockito.when(mockUserStore.getUser(TEST_USERNAME)).thenReturn(fakeUser);
@@ -154,6 +162,12 @@ public class ConversationServletTest {
     Mockito.when(mockConversationStore.isTitleTaken(TEST_CONVERSATION)).thenReturn(false);
 
     conversationServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<Tag> tagArgumentCaptor =
+        ArgumentCaptor.forClass(Tag.class);
+    Mockito.verify(mockTagStore).addTag(tagArgumentCaptor.capture());
+    Assert.assertEquals(tagArgumentCaptor.getValue().getTag(), TEST_TAG);
+
 
     ArgumentCaptor<Conversation> conversationArgumentCaptor =
         ArgumentCaptor.forClass(Conversation.class);

--- a/src/test/java/codeu/controller/TagServletTest.java
+++ b/src/test/java/codeu/controller/TagServletTest.java
@@ -101,7 +101,7 @@ public class TagServletTest {
 
     tagServlet.doGet(mockRequest, mockResponse);
 
-    Mockito.verify(mockRequest).setAttribute("extracted_tag", TEST_TAG);
+    Mockito.verify(mockRequest).setAttribute("extracted_tag", TEST_TAG.getTag());
     Mockito.verify(mockRequest).setAttribute("conversations", conversations);
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
@@ -127,22 +127,6 @@ public class TagServletTest {
   }
 
   @Test
-  public void testDoPost_NoNewTags() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/addtags/" + TEST_CONVO.getTitle());
-    Mockito.when(mockSession.getAttribute("user")).thenReturn(TEST_USERNAME);
-
-    userStore.addUser(TEST_USER);
-
-    messageStore.addMessage(TEST_MESSAGE);
-
-    tagServlet.doPost(mockRequest, mockResponse);
-
-    Mockito.verify(mockRequest).setAttribute("conversation", TEST_CONVO);
-    Mockito.verify(mockRequest).setAttribute("tags", TEST_CONVO.getTags());
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_convo");
-  }
-
-  @Test
   public void testDoPost_AddNewTags() throws IOException, ServletException {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/addtags/" + TEST_CONVO.getTitle());
     Mockito.when(mockSession.getAttribute("user")).thenReturn(TEST_USERNAME);
@@ -155,7 +139,7 @@ public class TagServletTest {
     tagServlet.doPost(mockRequest, mockResponse);
 
     Mockito.verify(mockRequest).setAttribute("conversation", TEST_CONVO);
-    Mockito.verify(mockRequest).setAttribute("tags", TEST_CONVO.getTags());
+    Mockito.verify(mockRequest).setAttribute("tags", tagStore.getTagsInConversation(TEST_CONVO.getId()));
     Mockito.verify(mockResponse).sendRedirect("/chat/test_convo");
   }
 }

--- a/src/test/java/codeu/controller/TagServletTest.java
+++ b/src/test/java/codeu/controller/TagServletTest.java
@@ -95,6 +95,7 @@ public class TagServletTest {
   @Test
     public void testDoGet() throws IOException, ServletException {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/tag/" + TEST_TAG.getTag());
+    Mockito.when(mockSession.getAttribute("user")).thenReturn(TEST_USERNAME);
     
     List<String> conversations = new ArrayList<>();
     conversations.add(TEST_CONVO.getTitle()); 

--- a/src/test/java/codeu/model/data/TagTest.java
+++ b/src/test/java/codeu/model/data/TagTest.java
@@ -12,22 +12,15 @@ public class TagTest {
   @Test
   public void testCreate() {
     UUID id = UUID.randomUUID();
-    UUID conv_id1 = UUID.randomUUID();
-    UUID conv_id2 = UUID.randomUUID();
+    UUID convo_id = UUID.randomUUID();
     String tag = "test_tag";
     Instant creation = Instant.now();
-    Conversation conversation1 = new Conversation(conv_id1, UUID.randomUUID(), "test", creation);
-    Conversation conversation2 = new Conversation(conv_id2, UUID.randomUUID(), "test", creation);
-    List<UUID> convo_ids = new ArrayList<>();
-    convo_ids.add(conversation1.getId());
-    convo_ids.add(conversation2.getId());
+    Conversation conversation = new Conversation(convo_id, UUID.randomUUID(), "test", creation);
 
-    Tag test_tag = new Tag(id, conversation1.getId(), tag, creation);
-    test_tag.addConversation(conversation2.getId());
+    Tag test_tag = new Tag(id, conversation.getId(), tag, creation);
 
     Assert.assertEquals(id, test_tag.getId());
-    Assert.assertEquals(conv_id1, test_tag.getConversation());
-    Assert.assertEquals(convo_ids, test_tag.getConversations());
+    Assert.assertEquals(convo_id, test_tag.getConversation());
     Assert.assertEquals(tag, test_tag.getTag());
     Assert.assertEquals(creation, test_tag.getCreationTime());
   }


### PR DESCRIPTION
- Removes references to Tags in Conversation objects, so as to not continuously be adding new Conversation objects to ConversationStore in memory. This resolves the issue of the same Conversation showing up multiple times in Conversations.jsp
- Removes references to lists of Conversation Ids in Tag objects. When a user types in a tag, a new Tag object is created. This is a bit easier to store Tags in Datastore, since entities take Strings and not list. This resolves the issue of Tags not persisting (we weren't adding them to DataStore properly with writeThrough previously)
- Adjusts appropriate tests